### PR TITLE
Fix setup.cfg to include all submodules using packages=find

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,10 @@ omit =
     fractal_analysis.py
     psd.py
     _*.py
+
+
+[options]
+packages = find:
+
+[options.packages.find]
+where = pymultifracs


### PR DESCRIPTION
This PR updates setup.cfg to use `packages = find:` and `where = pymultifracs` so that all submodules like `simul` are properly installed when using pip.

Tested in a fresh conda environment with `pip install .`, and confirmed that imports like:

`from pymultifracs.simul import mrw` 

all work as expected.